### PR TITLE
Update README.md to use single quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Also you can configure redis_pool directly from configuration file to get pools 
 
 ```
 config :redis_pool, :pools, [
-  test_pool:   [size: 10, hostname: "127.0.0.1", port: 6379],
-  test_pool_2: [size: 20, hostname: "127.0.0.1", port: 6379, database: "user_db", password: "abc", reconnect_sleep: "20"]
+  test_pool:   [size: 10, host: '127.0.0.1', port: 6379],
+  test_pool_2: [size: 20, host: '127.0.0.1', port: 6379, database: 'user_db', password: 'abc', reconnect_sleep: '20']
 ]
 ```
 


### PR DESCRIPTION
The correct key for `eredis` is `host` and not `hostname`... and the config values need to use single quotes.

I had to make these changes for the project to work.
