### PR TITLE
Bugfix/optional pool settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ Also you can configure redis_pool directly from configuration file to get pools 
 
 ```
 config :redis_pool, :pools, [
-  test_pool:   [size: 10, host: '127.0.0.1', port: 6379],
-  test_pool_2: [size: 20, host: '127.0.0.1', port: 6379, database: 'user_db', password: 'abc', reconnect_sleep: '20']
+  test_pool:   [size: 10],
+  test_pool_2: [size: 10, database: 111],
+  test_pool_3: [size: 20, host: '127.0.0.1', port: 6379, database: 'user_db', password: 'abc', reconnect_sleep: '20']
 ]
 ```
 

--- a/lib/redis_pool/supervisor.ex
+++ b/lib/redis_pool/supervisor.ex
@@ -36,7 +36,7 @@ defmodule RedisPool.Supervisor do
   def init([pools, global_or_local]) do
     spec_fun = fn({pool_name, pool_config}) ->
       args = [{:name, {global_or_local, pool_name}}, {:worker_module, :eredis}] ++ pool_config
-      :poolboy.child_spec(pool_name, args, pool_config)
+      :poolboy.child_spec(pool_name, args, [pool_config])
     end
     pool_specs = Enum.map(pools, spec_fun)
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule RedisPool.Mixfile do
 
   def project do
     [ app: :redis_pool,
-      version: "0.2.5",
+      version: "0.2.6",
       elixir: "> 1.0.0",
       description: description(),
       package: package(),

--- a/test/redis_pool_test.exs
+++ b/test/redis_pool_test.exs
@@ -82,7 +82,21 @@ defmodule RedisPoolTest do
     {:ok, _} = R.create_pool(:global_pool, 5)
     assert {:ok, "OK"} == R.q :global_pool, ["SET", "test8", "1"]
     assert {:ok, "1"} == R.q {:global, :global_pool}, ["GET", "test8"]
+  end
 
+  test "use default eredis settings" do
+    test_settings = fn(pool_settings) ->
+      Application.stop :redis_pool
+      Application.put_env :redis_pool, :pools, pool_settings
+      Application.start :redis_pool
+      {:ok, "OK"} = R.q :default, ["SET", "test9", "value"]
+      {:ok, "value"} = R.q :default, ["GET", "test9"]
+    end
+
+    test_settings.(default: [size: 10])
+    test_settings.(default: [size: 10, database: 111])
+    test_settings.(default: [size: 10, host: '127.0.0.1', port: 6379])
+    test_settings.(default: [size: 10, port: 6379, database: '0'])
   end
 
 end


### PR DESCRIPTION
Currently it's impossible to specify only some parameters for :eredis.
When I try to apply following configuration:
```elixir
config :redis_pool, :pools, [
  default: [size: 10, host: '127.0.0.1', port: 6379, database: 123]
]
```
The following error occurs:
```elixir
{:error, {:EXIT, {:function_clause, [{:eredis, :start_link, ['127.0.0.1', 6379, 123, [], 100, 5000], [file: '/app/deps/eredis/src/eredis.erl', line: 49]}
```
Expected behavior is to call :eredis.start_link/1 and pass proplist to let eredis use default settings.